### PR TITLE
fix: 修复构建镜像tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # bullseye必须加上，除非更新宿主机系统和docker
 # 参考：https://github.com/docker-library/golang/issues/467#issuecomment-1601845758
-FROM golang:1.21-bullseye AS build
+FROM golang:bullseye AS build
 
 ENV LANG=C.UTF-8
 ENV TZ=Asia/Shanghai


### PR DESCRIPTION
golang:1.21-bullseye 不存在于dockerhub 中，golang官方镜像通常只保留最新golang版本，因此使用golang:bullseye tag，以确保镜像获取成功